### PR TITLE
shhgit/session: improved config load

### DIFF
--- a/shhbt/session.py
+++ b/shhbt/session.py
@@ -1,5 +1,6 @@
 import logging
 from typing import Dict, List
+from re import error as RegexError
 
 import yaml
 
@@ -30,13 +31,16 @@ class Session:
                     )
                 )
             else:
-                signatures.append(
-                    PatternSignature(
-                        name=signature.get("name"),
-                        part=signature.get("part"),
-                        regex=signature.get("regex"),
+                try:
+                    signatures.append(
+                        PatternSignature(
+                            name=signature.get("name"),
+                            part=signature.get("part"),
+                            regex=signature.get("regex"),
+                        )
                     )
-                )
+                except RegexError:
+                    self._logger.exception("Failed loading signature. Offending entry: %s", signature)
         return signatures
 
     def _parse_blacklists(self) -> List[BlacklistItem]:

--- a/tests/data/config_with_invalid_regex.yaml
+++ b/tests/data/config_with_invalid_regex.yaml
@@ -1,0 +1,4 @@
+signatures:
+  - part: 'contents'
+    regex: "(?i)linkedin(.{0,20})?(?-i)[''\"][0-9a-z]{12}[''\"]"
+    name: 'No in-the-middle global modifiers for Python.'


### PR DESCRIPTION
Sometimes regular expressions can fail loading, thus we need better
error handling of this bit. The preference is to report those errors and
proceed with the next signature.