### PR TITLE
Bump dependencies to latest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 flask==2.0.3
 python-dotenv==0.16.0
-PyYaml==5.4.1
+PyYaml==6.0
 requests==2.27.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 
 black==22.1.0
-coveralls==3.0.1
+coveralls==3.3.1
 pre-commit==2.17.0
-pytest==6.2.4
-pytest-cov==2.11.1
+pytest==7.0.1
+pytest-cov==3.0.0


### PR DESCRIPTION
After the previous merge, #55, dependabot found newer upgrades.

Closes https://github.com/PaddyPowerBetfair/shhbt/pull/76, https://github.com/PaddyPowerBetfair/shhbt/pull/75, https://github.com/PaddyPowerBetfair/shhbt/pull/74 and https://github.com/PaddyPowerBetfair/shhbt/pull/73